### PR TITLE
Fix generate_db.py with recent numpy:

### DIFF
--- a/lib/generate_db.py
+++ b/lib/generate_db.py
@@ -113,7 +113,7 @@ def write_doc_doc(con, cur, gamma_file):
     con.commit()
 
     gamma = np.loadtxt(gamma_file)
-    theta = gamma / gamma.sum(1)
+    theta = gamma / gamma.sum(axis=1, keepdims=True)
 
     # get the closest 100 relations per document
     for a in range(len(theta)):


### PR DESCRIPTION
Fix generate_db.py with recent numpy:
ValueError: operands could not be broadcast together with shapes (X,Y) (X,)